### PR TITLE
Update Pkg.Json.StubField.pas - The declaration position of repeated classes has been fixed to always be declared before the classes that use them.

### DIFF
--- a/Lib/Pkg.Json.StubField.pas
+++ b/Lib/Pkg.Json.StubField.pas
@@ -105,12 +105,18 @@ uses
 class function TStubClass.Construct(aParentClass: TStubClass; aClassName: string; aStubClasses: TStubClassList; aArrayProperty: string): TStubClass;
 var
   StubClass: TJsonName;
+  lIndex: Integer;
 begin
   StubClass := aStubClasses.ItemByName(aClassName);
+
   if StubClass = nil then
     Result := TStubClass.Create(aParentClass, aClassName, aStubClasses, aArrayProperty)
   else
+  begin
+    lIndex := aStubClasses.IndexOf(StubClass as TStubClass);
+    aStubClasses.Move(lIndex, aStubClasses.Count - 1);
     Result := StubClass as TStubClass;
+  end;
 end;
 
 constructor TStubClass.Create(aParentClass: TStubClass; aClassName: string; aStubClasses: TStubClassList; aArrayProperty: string);


### PR DESCRIPTION
The declaration position of repeated classes has been fixed to always be declared before the classes that use them.

See this example:

`{
  "tipoOperacao": "I",
  "idEvento": "string",
  "dtHrOcorrencia": "2020-04-01T10:50:30.150Z-0300",
  "dtHrRegistro": "2020-04-01T10:50:30.150Z-0300",
  "cpfOperOcor": "55555555555",
  "cpfOperReg": "55555555555",
  "protocoloEventoRetifCanc": "string",
  "contingencia": false,
  "codRecinto": "1111111",
  "operacao": "C",
  "direcao": "E",
  "protocoloAgenda": "string",
  "dtHrAgenda": "2020-04-01T10:50:30.150Z-0300",
  "listaManifestos": [
    {
      "num": "string",
      "tipo": "DAT",
      "listaConhecimentos": [
        {
          "num": "string",
          "tipo": "AWB"
        }
      ]
    }
  ],
  "listaDiDue": [
    {
      "num": "string",
      "tipo": "DUIMP"
    }
  ],
  "listaNfe": "['nrNfe1', 'nrNfe2']",
  "listaMalas": "['mala1', 'mala2']",
  "tipoGranel": "S",
  "listaChassi": "['chassi1', 'chassi2']",
  "placa": "string",
  "ocrPlaca": false,
  "oogDimensao": false,
  "oogPeso": false,
  "listaSemirreboque": [
    {
      "placa": "string",
      "ocrPlaca": false,
      "vazio": false,
      "listaLacres": [
        {
          "num": 99,
          "tipo": "REC",
          "localSif": "string"
        }
      ],
      "avaria": false,
      "cnpjCliente": "44444444444444",
      "nmCliente": "string"
    }
  ],
  "listaConteineresUld": [
    {
      "num": "string",
      "tipo": "ULD",
      "ocrNum": false,
      "vazio": false,
      "numBooking": "string",
      "listaLacres": [
        {
          "num": 99,
          "tipo": "REC",
          "localSif": "string"
        }
      ],
      "avaria": false,
      "portoDescarga": "string",
      "destinoCarga": "string",
      "imoNavio": "string",
      "cnpjCliente": "44444444444444",
      "nmCliente": "string"
    }
  ],
  "cnpjTransportador": "44444444444444",
  "nmTransportador": "string",
  "motorista": {
    "protocoloCredenciamento": "string",
    "cpf": "55555555555",
    "nome": "string"
  },
  "codRecintoDestino": 0,
  "modal": "R",
  "gate": "string",
  "listaCameras": "['camera1', 'camera2']"
}`