### PR TITLE
Issue: Out of memory error and High CPU usage

### DIFF
--- a/Generator GUI/MainFormU.fmx
+++ b/Generator GUI/MainFormU.fmx
@@ -123,6 +123,7 @@ object MainForm: TMainForm
             '"'
           ''
           'See also the possibilities in the MenuBar')
+        OnChangeTracking = MemoJSONChangeTracking
         Align = Client
         Size.Width = 613.000000000000000000
         Size.Height = 355.000000000000000000

--- a/Generator GUI/MainFormU.pas
+++ b/Generator GUI/MainFormU.pas
@@ -74,10 +74,14 @@ type
     procedure Label1Click(Sender: TObject);
     procedure ActionList1Update(Action: TBasicAction; var Handled: Boolean);
     procedure EditClassNameChange(Sender: TObject);
+    procedure MemoJSONChangeTracking(Sender: TObject);
+  private type
+    TValidationTypes = (vtUnchecked, vtValid, vtInvalid);
   private
     { Private declarations }
     FCheckVersionResponse: TRelease;
     FJsonMapper: TPkgJsonMapper;
+    FIsValid: TValidationTypes;
   public
     { Public declarations }
   end;
@@ -211,8 +215,18 @@ begin
   if not OutputFormatDict.TryGetValue(TabControl1.ActiveTab, OutputFormat) then
     OutputFormat := nil;
 
-  actConvert.Enabled := FJsonMapper.IsValid(MemoJSON.Text.Trim);
+  if FIsValid = vtUnchecked then
+    if FJsonMapper.IsValid(MemoJSON.Text.Trim) then
+      FIsValid := vtValid
+    else
+      FIsValid := vtInvalid;
+  actConvert.Enabled := FIsValid = vtValid;
   actSaveAs.Enabled := (OutputFormat <> nil) and (actConvert.Enabled);
+end;
+
+procedure TMainForm.MemoJSONChangeTracking(Sender: TObject);
+begin
+  FIsValid := vtUnchecked;
 end;
 
 procedure TMainForm.actOnlineValidationExecute(Sender: TObject);

--- a/Lib/Pkg.Json.Mapper.pas
+++ b/Lib/Pkg.Json.Mapper.pas
@@ -268,8 +268,13 @@ begin
 end;
 
 function TPkgJsonMapper.IsValid(aJsonString: string): boolean;
+var
+  Value: TJSONValue;
 begin
-  Result := TJSONObject.ParseJSONValue(aJsonString) <> nil;
+  Value := TJSONObject.ParseJSONValue(aJsonString);
+  Result := Value <> nil;
+  if Result then
+    Value.Free;
 end;
 
 function TPkgJsonMapper.LoadFormFile(aJsonFile: string): TPkgJsonMapper;


### PR DESCRIPTION
I found that once a JSON document was loaded into MemoJSON than the Action List Update calls were checking JSON IsValid continuously causing high CPU usage and when the JSON is valid, the parsed JSON object in IsValid was leaked which quickly leads to an Out of Memory error.  The suggested change is to only validate the JSON when MemoJSON has been changed as well as free the leaked TJSONObject in TPkgJsonMapper.IsValid.  To test, paste a sizable valid JSON doc in the memo and watch CPU and memory.  Out of Memory errors occurred pretty quickly in my testing of sizeable JSON content.
[SampleJSON.zip](https://github.com/JensBorrisholt/Delphi-JsonToDelphiClass/files/6217138/SampleJSON.zip)